### PR TITLE
Add terminal chat example

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,31 @@
+import os
+import openai
 
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def main():
+    if not openai.api_key:
+        raise RuntimeError("Please set the OPENAI_API_KEY environment variable.")
+    messages = []
+    print("Type 'exit' or 'quit' to stop the chat.")
+    while True:
+        try:
+            user_input = input("You: ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages,
+        )
+        reply = response["choices"][0]["message"]["content"].strip()
+        messages.append({"role": "assistant", "content": reply})
+        print("Assistant:", reply)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement an interactive chat example in `main.py`

## Testing
- `python3 -m pip show openai`
- `python3 -m pip install openai --quiet` *(fails: `Tunnel connection failed: 403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_685a91567b58832691b17eaa07ca5f0f